### PR TITLE
Remove extra argument from function call

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -67,7 +67,7 @@ int main ()
 
   char* dungeon = nullptr;
 
-  dungeon = create_dungeon(dungeon, width, height, start_point, exit_point);
+  dungeon = create_dungeon(width, height, start_point, exit_point);
 
   traversal(dungeon, startPoint, exit_point, width, height);
 


### PR DESCRIPTION
The function `create_dungeon`  does not accept `char* dungeon` as its first argument. Removing it from the function call to fix the issue.  